### PR TITLE
updating step for wheel on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To use the SPL follow the next steps:
    
    `pip install -r requirements.txt`
 
+   ** In case that you are running Ubuntu, please install the package python3.9-dev and update wheel and setuptools with the command `pip  install --upgrade pip wheel setuptools` right after step 4.
 ### Execution
 To execute the SPL run the following command:
 


### PR DESCRIPTION
There are some failures when installing requirements in ubuntu. Python3.9-dev is needed as well as updating setup tools and wheel python packages. 